### PR TITLE
ALPHA-2995: Fix index out of range in peek() in decode.go

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -371,6 +371,10 @@ func (d *Decoder) scanWhile(state int) {
 }
 
 func (d *Decoder) peek(n int) byte {
+	var bytesRead = d.bytesRead + n
+	if bytesRead >= len(d.buf) {
+		bytesRead = len(d.buf) - 1
+	}
 	return d.buf[d.bytesRead+n]
 }
 


### PR DESCRIPTION
Fix index out of range

```shell
runtime error: index out of range [97280] with length 97280
panic.go:88 (0x4332c4)
decode.go:374 (0x5112ef)
```